### PR TITLE
Work around oti indexing problem, see peyotl issue 126

### DIFF
--- a/src/main/java/org/opentree/nexson/io/NexsonNode.java
+++ b/src/main/java/org/opentree/nexson/io/NexsonNode.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import jade.tree.JadeNode;
 import jade.tree.NodeOrder;
 import jade.tree.TreeNode;
 
@@ -232,7 +231,15 @@ public class NexsonNode extends NexsonElement implements TreeNode {
 				assignOTU(parentTree.getParentStudy().getOTUById(otuId)); // will assign null if the parent study has no OTUs
 
 			} else if (isLeaf) { // fail case
-				throw new NexsonParseException("The node " + getId() + " is identified as a leaf but has not been assigned an OTU.");
+                NexsonParseException e = new NexsonParseException("The node " + getId() + " is identified as a leaf but has not been assigned an OTU.");
+                if (false)
+                    throw e;
+                else {
+                    // See https://github.com/OpenTreeOfLife/peyotl/issues/126
+                    // and https://github.com/OpenTreeOfLife/oti/issues/34  -JAR
+                    System.err.println(e);
+                    assignOTU(null);
+                }
 			}
 		}
 	}


### PR DESCRIPTION
This is just a temporary workaround. It will work fine for OTI, but may not play nicely with treemachine.  See https://github.com/OpenTreeOfLife/peyotl/issues/126 and https://github.com/OpenTreeOfLife/oti/issues/34 .

    $ curl -X POST http://devapi.opentreeoflife.org/v2/studies/index_studies -H 'content-type:application/json' -d '{"urls": ["http://api.opentreeoflife.org/phylesystem/v1/../default/v1/study/ot_31.json"]}'
    {
      "indexed" : [ "ot_31" ],
      "errors" : {
      }
    }