### PR TITLE
Suppress bogus 'validation'

### DIFF
--- a/src/main/java/org/opentree/nexson/io/NexsonTree.java
+++ b/src/main/java/org/opentree/nexson/io/NexsonTree.java
@@ -245,11 +245,11 @@ public class NexsonTree extends NexsonElement implements Tree {
 		}
 
 		// Validation, assumes nexson edge polarity matches tree edge polarity (it should).
-		if (specifiedRoot != null && specifiedRoot != observedRoot) {
+		if (specifiedRoot != null && !specifiedRoot.equals(observedRoot)) {
             NexsonParseException e =
                 new NexsonParseException("The specified root node " + specifiedRoot.getId() +
                                          " is different from the observed root of the tree in the NexSON object hierarchy. This is nonsensical.");
-            if (false)
+            if (true)
                 throw e;
             else {
                 System.err.println(e); // should show study id as well  this.parentStudy

--- a/src/main/java/org/opentree/nexson/io/NexsonTree.java
+++ b/src/main/java/org/opentree/nexson/io/NexsonTree.java
@@ -253,7 +253,6 @@ public class NexsonTree extends NexsonElement implements Tree {
                 throw e;
             else {
                 System.err.println(e); // should show study id as well  this.parentStudy
-                assignOTU(null);
             }
 		}
 		

--- a/src/main/java/org/opentree/nexson/io/NexsonTree.java
+++ b/src/main/java/org/opentree/nexson/io/NexsonTree.java
@@ -249,7 +249,7 @@ public class NexsonTree extends NexsonElement implements Tree {
             NexsonParseException e =
                 new NexsonParseException("The specified root node " + specifiedRoot.getId() +
                                          " is different from the observed root of the tree in the NexSON object hierarchy. This is nonsensical.");
-            if (true)
+            if (false)
                 throw e;
             else {
                 System.err.println(e); // should show study id as well  this.parentStudy

--- a/src/main/java/org/opentree/nexson/io/NexsonTree.java
+++ b/src/main/java/org/opentree/nexson/io/NexsonTree.java
@@ -246,8 +246,15 @@ public class NexsonTree extends NexsonElement implements Tree {
 
 		// Validation, assumes nexson edge polarity matches tree edge polarity (it should).
 		if (specifiedRoot != null && specifiedRoot != observedRoot) {
-			throw new NexsonParseException("The specified root node " + specifiedRoot.getId() +
-					" is different from the observed root of the tree in the NexSON object hierarchy. This is nonsensical.");
+            NexsonParseException e =
+                new NexsonParseException("The specified root node " + specifiedRoot.getId() +
+                                         " is different from the observed root of the tree in the NexSON object hierarchy. This is nonsensical.");
+            if (false)
+                throw e;
+            else {
+                System.err.println(e); // should show study id as well  this.parentStudy
+                assignOTU(null);
+            }
 		}
 		
 		// GraphImporter looks for root as node with no parents, so we set this here. This seems unnecessary...


### PR DESCRIPTION
The bug would be fixed, maybe, by https://github.com/OpenTreeOfLife/ot-base/commit/7da7b4ad53d89b48fb78c223df7baf50811016e8
but the fix creates compilation errors in oti, and besides which hasn't been tested.
This PR simply suppresses the check.
